### PR TITLE
Stop unlinking non-existing file

### DIFF
--- a/src/PdfToImage.php
+++ b/src/PdfToImage.php
@@ -27,9 +27,6 @@ class PdfToImage
                 'pdf_page_count' => $pdf->getNumberOfPages(),
                 'pdf_converted_page' => $pageNumber
             ])->save();
-
-            unlink($imageFilePath);
-
         }
 
     }


### PR DESCRIPTION
Somewhere between Statamic `3.3.63` and `3.4.5` this addon started to throw the following error upon each PDF upload:

```myfile.pdf unlink(/Users/myuser/www/mysite/storage/myfile.jpg): No such file or directory```

Both, upload and image generation worked as expected, but a reload of the panel is necessary to actually see both the uploaded PDF and the generated image (which can cause users to upload the same file multiple times, as it seems like it didn't work).

I'm not a PHP dev, but it looks like unlinking the image has become obsolete with some core update that happened between the mentioned versions. Curious if this is correct. 